### PR TITLE
Removing canonical link

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,6 @@
 
   <title>{$ title $}</title>
 
-  <link href="{$ url $}" rel="canonical">
-
   <link href="images/favicon.ico" rel="icon">
 
   <meta content="{$ webapp.themeColor $}" name="theme-color">


### PR DESCRIPTION
FB is dulicating the link based on canonical link. Thats why its throwing an error while fetching the content.
It can be debugged at https://developers.facebook.com/tools/debug/og/object/