### PR TITLE
bookmark button disabled

### DIFF
--- a/src/elements/dialogs/session-details.html
+++ b/src/elements/dialogs/session-details.html
@@ -24,6 +24,10 @@
       .section {
         cursor: pointer;
       }
+
+      paper-fab {
+        display:none; // setting display none to avoid signin
+      }
     </style>
 
     <polymer-helmet

--- a/src/elements/session-element.html
+++ b/src/elements/session-element.html
@@ -62,6 +62,7 @@
 
       .bookmark-session {
         color: var(--secondary-text-color);
+        display: none;
       }
 
       .session[featured] .bookmark-session {


### PR DESCRIPTION
"display: none" set for .bookmark-session class and paper-fab element in order to disable accidental signin.